### PR TITLE
fix(test): CI 跑机管理员环境下 MFT 整卷枚举拖慢测试

### DIFF
--- a/crates/dowse-core/tests/e2e_watch.rs
+++ b/crates/dowse-core/tests/e2e_watch.rs
@@ -24,7 +24,13 @@ const BUDGET: Duration = Duration::from_secs(3);
 /// 轮询上限：给"功能最终是否生效"用，要远松于 BUDGET——CI 共享跑机偶尔
 /// 会慢到 15s 都不够，之前用 15s 就是随机超时的根源，放宽到 30s。这个
 /// 上限不代表性能预算，只是"再等下去就该判失败了"的兜底。
-const POLL_TIMEOUT: Duration = Duration::from_secs(30);
+///
+/// 30s 后来在 CI 上又炸过一次（run 29173139308，重命名新名字那一步）：这个
+/// 测试自己的 `rebuild_index` 在 CI 的系统盘（管理员权限 + NTFS，触发 MFT
+/// 快速枚举整卷 C:，~130 万条记录）上就要吃掉 30s 量级（见
+/// tests/ntfs_fast_path.rs 模块文档的排障记录），把跑机进一步拖慢，导致
+/// 紧接着的 notify 事件传播/防抖/commit 偶尔也需要更久。再放宽到 60s。
+const POLL_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// CI 环境下（GitHub Actions 默认设了 `CI=true`）跳过严格的延迟预算断言，
 /// 只用于人读的耗时数字打印时标注清楚这条判断为什么被跳过。

--- a/crates/dowse-core/tests/ntfs_fast_path.rs
+++ b/crates/dowse-core/tests/ntfs_fast_path.rs
@@ -6,6 +6,25 @@
 //! - 真正走快车道（MFT 枚举 + USN Journal）需要管理员权限打开原始卷句柄，
 //!   测试开头先用 `dowse_core::ntfs_fast_path_available()` 探测一次，拿不到就打印
 //!   原因跳过，不让非管理员的开发机/CI 把构建搞红。
+//!
+//! CI 排障记录（GitHub Actions windows-latest 连续几次全红后追出来的根因）：
+//! `rebuild_index`/`watch_roots_auto` 在管理员+NTFS 环境下走 MFT 快速枚举时，
+//! 枚举的是**整卷**（不是只扫监听根），CI 跑机的系统盘 C: 本身就有 ~130 万条
+//! MFT 记录，单次整卷枚举实测耗时 30 秒量级——远超设计文档"100 万条 < 5s"的
+//! 本地预算（那是本机文件数少得多时测的）。三个测试本来就默认并行跑在同一个
+//! 进程里，每个测试至少一次 rebuild_index（一次整卷枚举），
+//! `mft_enumeration_and_usn_watch_when_admin_available`/
+//! `rapid_rename_then_delete_leaves_no_orphan_document` 还会在 `watch_roots_auto`
+//! 里通过 `bootstrap_fast_roots` 再枚举一次——三个测试一起对同一块系统盘发起
+//! 2~4 次并发整卷扫描，互相抢 I/O，把原本单次就要 30s 的枚举拖得更久，
+//! 经常在事件真正开始被 USN 监听捕获之前就把下面的 `POLL_TIMEOUT` 耗光。
+//! 这不是功能回归——USN 事件源本身工作正常，只是"建立监听前的必经枚举"在这块
+//! 系统盘上的真实耗时远超测试原来给的等待预算。修法两条都用上：
+//! 1) 用 `TEST_SERIAL_LOCK` 把三个测试串行化，去掉同卷并发扫描互相抢 I/O 的
+//!    额外损耗；
+//! 2) `POLL_TIMEOUT` 放宽到能舒服装下"一次整卷枚举 + 事件真正传播"的量级——
+//!    这是"再等下去就该判失败了"的兜底线，不是性能预算断言，放宽不影响这条
+//!    测试本来要验的东西（USN 事件源最终有没有正确捕获变更）。
 
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -17,7 +36,18 @@ use dowse_core::{
     IndexUpdater, Searcher, ntfs_fast_path_available, rebuild_index, watch_roots_auto,
 };
 
-const POLL_TIMEOUT: Duration = Duration::from_secs(30);
+mod common;
+
+/// 三个测试共用的串行锁：见上面模块文档里的排障记录——同一块系统盘上的并发
+/// MFT 整卷枚举会互相抢 I/O，串行化换来的是每个测试自己独立的、可预期的
+/// 枚举耗时，而不是叠加在一起的抢占延迟。
+static TEST_SERIAL_LOCK: Mutex<()> = Mutex::new(());
+
+/// 轮询上限：不是性能预算，是"再等下去就该判失败了"的兜底。放宽到 120s 是为了
+/// 舒服装下 CI 系统盘上一次整卷 MFT 枚举（实测 30s 量级，见模块文档）—— 部分
+/// 场景（游标补账前重新枚举）等于要连续吃两次这个耗时，留够余量避免真实事件
+/// 已经被正确捕获、只是枚举还没扫完就被判超时。
+const POLL_TIMEOUT: Duration = Duration::from_secs(120);
 
 fn target_dir(prefix: &str) -> tempfile::TempDir {
     tempfile::Builder::new().prefix(prefix).tempdir().unwrap()
@@ -50,6 +80,7 @@ fn wait_until(
 /// 这正是"上层感知不到差别"的可执行验收。
 #[test]
 fn watch_roots_auto_add_delete_rename_end_to_end() -> Result<()> {
+    let _serial = TEST_SERIAL_LOCK.lock().expect("ntfs 测试串行锁 poisoned");
     let index_dir = tempfile::tempdir()?;
     let target = target_dir("dowse-m6-auto-");
 
@@ -90,6 +121,9 @@ fn watch_roots_auto_add_delete_rename_end_to_end() -> Result<()> {
 
     stop.store(true, Ordering::Relaxed);
     let _ = watch_handle.join();
+    drop(updater);
+    common::close_tempdir_retrying(index_dir);
+    common::close_tempdir_retrying(target);
     Ok(())
 }
 
@@ -98,6 +132,7 @@ fn watch_roots_auto_add_delete_rename_end_to_end() -> Result<()> {
 /// 非管理员环境（大多数开发机/CI 默认状态）打印原因跳过，不算失败。
 #[test]
 fn mft_enumeration_and_usn_watch_when_admin_available() -> Result<()> {
+    let _serial = TEST_SERIAL_LOCK.lock().expect("ntfs 测试串行锁 poisoned");
     let target = target_dir("dowse-m6-fast-");
 
     if !ntfs_fast_path_available(target.path()) {
@@ -169,6 +204,9 @@ fn mft_enumeration_and_usn_watch_when_admin_available() -> Result<()> {
 
     stop.store(true, Ordering::Relaxed);
     let _ = watch_handle.join();
+    drop(updater);
+    common::close_tempdir_retrying(index_dir);
+    common::close_tempdir_retrying(target);
     Ok(())
 }
 
@@ -178,6 +216,7 @@ fn mft_enumeration_and_usn_watch_when_admin_available() -> Result<()> {
 /// 真实的调度节奏，不是人为构造的记录序列。
 #[test]
 fn rapid_rename_then_delete_leaves_no_orphan_document() -> Result<()> {
+    let _serial = TEST_SERIAL_LOCK.lock().expect("ntfs 测试串行锁 poisoned");
     let target = target_dir("dowse-m6-rapid-");
 
     if !ntfs_fast_path_available(target.path()) {
@@ -222,6 +261,9 @@ fn rapid_rename_then_delete_leaves_no_orphan_document() -> Result<()> {
 
     stop.store(true, Ordering::Relaxed);
     let _ = watch_handle.join();
+    drop(updater);
+    common::close_tempdir_retrying(index_dir);
+    common::close_tempdir_retrying(target);
     Ok(())
 }
 

--- a/crates/dowse-core/tests/ocr_pipeline.rs
+++ b/crates/dowse-core/tests/ocr_pipeline.rs
@@ -13,10 +13,36 @@
 
 use std::path::Path;
 use std::process::Command;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 
 mod common;
+
+/// 轮询上限：见下面 `ocr_queue_survives_restart_and_resumes_pending_work` 的
+/// 排障记录——两个 worker 并发处理两张图片时，索引提交到能被一个全新打开的
+/// `Searcher` 读到之间偶发有 CI 才会撞上的短暂延迟，这条测试原来直接开
+/// `Searcher::open` 后立即断言，是本仓库里唯一一处对"刚写完的索引"不走轮询
+/// 就下断言的地方（e2e_watch.rs/ntfs_fast_path.rs 对同类断言全部走的是
+/// wait_until 轮询）。跟那两个文件用同一个套路补上，不改断言本身要验的东西。
+const SEARCH_VISIBLE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// 反复开只读 Searcher 搜 query，直到命中数满足 predicate 或超时。
+fn wait_until_searchable(index_dir: &Path, query: &str, predicate: impl Fn(usize) -> bool) -> bool {
+    let start = Instant::now();
+    loop {
+        if let Ok(searcher) = dowse_core::Searcher::open(index_dir)
+            && let Ok(hits) = searcher.search(query, 10)
+            && predicate(hits.len())
+        {
+            return true;
+        }
+        if start.elapsed() > SEARCH_VISIBLE_TIMEOUT {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
 
 // 纯小写字母数字、不含分隔符——跟 searcher.rs 测试里 "zzzsentinelprobe888" 同一个
 // 套路：jieba 分词器会把这样一整串 ASCII 当成单个 token，搜索时不用担心被切碎。
@@ -155,13 +181,14 @@ fn ocr_queue_survives_restart_and_resumes_pending_work() -> Result<()> {
     let second_pass = dowse_core::drain_ocr_queue(index_dir.path(), 2)?;
     assert_eq!(second_pass.processed, 0, "队列应已清空，不该重复处理");
 
-    let searcher = dowse_core::Searcher::open(index_dir.path())?;
     for i in 0..2 {
-        let hits = searcher.search(&format!("{SENTINEL}x{i}"), 10)?;
-        assert!(!hits.is_empty(), "第 {i} 张图片的哨兵词应该能搜到");
+        let query = format!("{SENTINEL}x{i}");
+        assert!(
+            wait_until_searchable(index_dir.path(), &query, |n| n > 0),
+            "第 {i} 张图片的哨兵词应该能搜到"
+        );
     }
 
-    drop(searcher);
     common::close_tempdir_retrying(index_dir);
     common::close_tempdir_retrying(target_dir);
     Ok(())


### PR DESCRIPTION
CI windows-latest 以管理员运行,M6 快车道激活并整卷枚举 1.3M 记录的系统盘(~30s),三个测试并发争抢致超时。测试侧修复:串行锁、轮询预算放宽、单点断言轮询化。产品代码零改动。